### PR TITLE
Fixed Mac Error, that LearnProjects could not be loaded.

### DIFF
--- a/src/components/ShowLearnProjects.style.ts
+++ b/src/components/ShowLearnProjects.style.ts
@@ -5,6 +5,7 @@ export const ShowLearnProjectsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  width: 100%;
 
   ::-webkit-scrollbar {
     width: 0;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -20,7 +20,7 @@ declare global {
       getLocalLearnProjectAndLearnPages: () => LearnProjects;
       learnPage: {
         load: (learnProject: string, learnPage: string) => string;
-        save: (content: string, title: string, learnProject: string) => void;
+        save: (content: string, title?: string, learnProject?: string) => [string,string];
       };
       openExternalLink: (link: string) => void;
     };

--- a/src/pages/EditSelectionPage.style.ts
+++ b/src/pages/EditSelectionPage.style.ts
@@ -4,5 +4,6 @@ export const EditSelectionPageWrapper = styled.div`
   display: grid;
   background-color: ${(p) => p.theme.backgroundColor};
   grid-template-columns: 1fr 1fr;
-  padding: 1rem;
+  padding-left: 1rem;
+  overflow: auto;
 `;

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -36,7 +36,9 @@ export function StartPage() {
           <StartPageButton>create</StartPageButton>
         </StartPageNavLink>
       </StartPageButtonWrapper>
-      <ShowLearnProjects learnProjects={learnProjects} />
+      <div style={{ width: '50%', overflow: 'auto' }}>
+        <ShowLearnProjects learnProjects={learnProjects} />
+      </div>
     </StartPageWrapper>
   );
 }


### PR DESCRIPTION
Put LearnPage 'untitled' Logic into preload.js to avoid overwritting the untitled.lap file. The ShowLEarnProjects component takes now 100% width to make scrolling easier. Fixed bug where you could not scroll in the EditSelectionPage component.