### PR TITLE
Updated ReadMe.md and Electron version.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,21 +2,33 @@
 
 ![Learn Page Example](./ReadMeContents/Lerny%20App%20example%20Learn%20Page%20showcase.jpg 'Learn Page')
 
-# Dependencies
+# Set up Development Environment
 
-- check if you have the required Dependencies of [node-pty](https://www.npmjs.com/package/node-pty)
-- "xdg-utils" are needed on Linux to open external Links in LearnPages
+- clone project
+- use node version v16.14.2
+  - nvm install 16.14.2
+  - nvm use 16.14.2
+- check "node-pty" dependencies:
+  - [node-pty](https://www.npmjs.com/package/node-pty)
+    <br>
+    For example on Windows:
+    - make sure python3 is installed
+    - install the [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk) features for "Desktop C++ Apps"
+    - npm install --global --production windows-build-tools
+- npm i
+- npm run start
 
-# Possible install errors:
+## Hints and possible Problems
 
-- contpty.node was compiled against a different Node.js version
-  - do: `./node_modules/.bin/electron-rebuild`
+### "contpty.node" was compiled against a different Node.js version
+
+- do: `./node_modules/.bin/electron-rebuild`
+
+### External Links on Linux
+
+- "xdg-utils" are needed to be installed to open external Links in LearnPages
 
 # Build from source:
 
-- clone Project
-- open Terminal in Project
-- npm i (Node v16.14.2 is required)
-- ./node_modules/.bin/electron-rebuild
+- setup Development Environment
 - npm run build
-- then you can find your finished build in the "out" directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "concurrently": "7.6.0",
         "cross-env": "7.0.3",
         "css-loader": "6.7.2",
-        "electron": "22.0.0",
+        "electron": "22.1.0",
         "electron-devtools-installer": "3.2.0",
         "electron-packager": "17.1.1",
         "electron-reload": "2.0.0-alpha.1",
@@ -5065,9 +5065,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.0.0.tgz",
-      "integrity": "sha512-cgRc4wjyM+81A0E8UGv1HNJjL1HBI5cWNh/DUIjzYvoUuiEM0SS0hAH/zaFQ18xOz2ced6Yih8SybpOiOYJhdg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-22.1.0.tgz",
+      "integrity": "sha512-wz5s4N6V7zyKm4YQmXJImFoxO1Doai32ShYm0FzOLPBMwLMdQBV+REY+j1opRx0KJ9xJEIdjYgcA8OSw6vx3pA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "concurrently": "7.6.0",
     "cross-env": "7.0.3",
     "css-loader": "6.7.2",
-    "electron": "22.0.0",
+    "electron": "22.1.0",
     "electron-devtools-installer": "3.2.0",
     "electron-packager": "17.1.1",
     "electron-reload": "2.0.0-alpha.1",


### PR DESCRIPTION
ReadMe now explains in more detail on how to get the node-pty dependencies installed.